### PR TITLE
fix: push to release branch to create release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,12 +2,13 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 on:
   push:
     branches:
-      - main
+      - release
     paths:
       - 'src/**'
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
+      - release
       - main
 permissions:
   contents: read


### PR DESCRIPTION
Changed specifications so that releases are created by pushing to the release branch